### PR TITLE
Fix ArrayInput source key typo from "tag" to "tags"

### DIFF
--- a/src/items/ItemEditDetails.tsx
+++ b/src/items/ItemEditDetails.tsx
@@ -79,7 +79,7 @@ export const ItemEditDetails = () => {
             </Grid>
 
             <Grid item xs={12}>
-                <ArrayInput source="tag" label="Tags">
+                <ArrayInput source="tags" label="Tags">
                     <SimpleFormIterator>
                         <TextInput source="title" label="Title" />
                         <NumberInput source="id" style={{ display: 'none' }} />


### PR DESCRIPTION
Updated the `source` key in the `ArrayInput` component to match the correct field name. This prevents potential issues with data mapping or rendering in the form interface.